### PR TITLE
dartboard to hook with render props

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,1 +1,2 @@
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"/>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss/dist/tailwind.min.css"/>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Please use [conventional commits](https://www.conventionalcommits.org) with the 
 - `layer-selector`
 - `sherlock`
 - `helpers`
+- `dart-board`
 
 ### `npm run build`
 

--- a/packages/dartboard/src/Dartboard.js
+++ b/packages/dartboard/src/Dartboard.js
@@ -85,6 +85,8 @@ const TailwindDartboard = (props) => {
     getFirstInputProps,
     getSecondInputProps,
     getButtonProps,
+    getFirstHelpProps,
+    getSecondHelpProps,
     isFirstInputValid,
     isSecondInputValid,
     found
@@ -99,7 +101,8 @@ const TailwindDartboard = (props) => {
           className="mb-2 block mt-1 bg-white rounded border border-gray-400 text-gray-700 focus:outline-none focus:border-indigo-500 w-full text-base px-3 py-2"
         ></input>
         {!isFirstInputValid ?
-          <small className="block text-red-600 text-xs -mt-2">A street is required</small>
+          <small {...getFirstHelpProps()}
+            className="block text-red-600 text-xs -mt-2"></small>
           : null}
       </div>
       <div className="group">
@@ -109,7 +112,8 @@ const TailwindDartboard = (props) => {
           className="mb-2 block mt-1 bg-white rounded border border-gray-400 text-gray-700 focus:outline-none focus:border-indigo-500 w-full text-base px-3 py-2"
         ></input>
         {!isSecondInputValid ?
-          <small className="block text-red-600 text-xs -mt-2">A city or zip is required</small>
+          <small {...getSecondHelpProps()}
+            className="block text-red-600 text-xs -mt-2"></small>
           : null}
       </div>
       <div className="group">
@@ -177,6 +181,16 @@ const useDartboard = (userProps={}) => {
       : 'dartboard_route_input',
     onKeyPress: handleKeyPress,
     autoComplete: 'nope',
+    ...inputProps
+  });
+
+  const getFirstHelpProps = (inputProps) => ({
+    children: props.type === ADDRESS_TYPE ? 'A street address is required' : 'A highway route number is required',
+    ...inputProps
+  });
+
+  const getSecondHelpProps = (inputProps) => ({
+    children: props.type === ADDRESS_TYPE ? 'A city or zip code is required' : 'A milepost number is required',
     ...inputProps
   });
 
@@ -324,6 +338,8 @@ const useDartboard = (userProps={}) => {
     getFirstInputProps,
     getSecondInputProps,
     getButtonProps,
+    getFirstHelpProps,
+    getSecondHelpProps,
     isFirstInputValid: firstIsValid,
     isSecondInputValid: secondIsValid,
     found

--- a/packages/dartboard/src/Dartboard.js
+++ b/packages/dartboard/src/Dartboard.js
@@ -302,7 +302,7 @@ const useDartboard = (userProps={}) => {
     setSecondIsValid(secondValidity);
 
     // reset not found message
-    setFound(undefined);
+    setFound(null);
 
     return firstValidity && secondValidity;
   }, [firstInput, secondInput]);

--- a/packages/dartboard/src/Dartboard.js
+++ b/packages/dartboard/src/Dartboard.js
@@ -32,6 +32,14 @@ const defaultProps = {
   }
 };
 
+const sanitize = (attributes={}) => {
+  const dartboardCustomProps = ['beforeClick', 'beforeKeyUp'];
+
+  return Object.keys(attributes)
+    .filter(key => dartboardCustomProps.indexOf(key) === -1)
+    .reduce((res, key) => (res[key] = attributes[key], res), {});
+};
+
 const BootstrapDartboard = (props) => {
   const { getFirstLabelProps,
     getSecondLabelProps,
@@ -67,7 +75,9 @@ const BootstrapDartboard = (props) => {
       </div>
       <div className="form-group">
         <button
-          {...getButtonProps()}
+          {...getButtonProps({
+            beforeClick: () => false
+          })}
           className="btn btn-outline-dark"
         >Find</button>
         {found === false ?
@@ -169,9 +179,9 @@ const useDartboard = (userProps={}) => {
     name: props.type === ADDRESS_TYPE
       ? 'dartboard_street_input'
       : 'dartboard_milepost_input',
-    onKeyPress: handleKeyPress,
-    autoComplete: 'nope',
-    ...inputProps
+    onKeyUp: (e) => inputProps?.beforeKeyUp(e) && handleKeyUp(e),
+    autoComplete: 'new-password',
+    ...sanitize(inputProps)
   });
 
   const getSecondInputProps = (inputProps) => ({
@@ -179,9 +189,9 @@ const useDartboard = (userProps={}) => {
     name: props.type === ADDRESS_TYPE
       ? 'dartboard_zone_input'
       : 'dartboard_route_input',
-    onKeyPress: handleKeyPress,
-    autoComplete: 'nope',
-    ...inputProps
+    onKeyUp: (e) => inputProps?.beforeKeyUp(e) && handleKeyUp(e),
+    autoComplete: 'new-password',
+    ...sanitize(inputProps)
   });
 
   const getFirstHelpProps = (inputProps) => ({
@@ -195,8 +205,8 @@ const useDartboard = (userProps={}) => {
   });
 
   const getButtonProps = (buttonProps) => ({
-    onClick: find,
-    ...buttonProps
+    onClick: (e) => buttonProps?.beforeClick(e) && find(e),
+    ...sanitize(buttonProps)
   });
 
   const find = useCallback(async () => {
@@ -227,7 +237,7 @@ const useDartboard = (userProps={}) => {
     }
   }, [firstInput, secondInput, validate, props.events, get, extractResponse]);
 
-  const handleKeyPress = useCallback((event) => {
+  const handleKeyUp = useCallback((event) => {
     if (event.key !== 'Enter') {
       return;
     }
@@ -333,6 +343,7 @@ const useDartboard = (userProps={}) => {
   }, [props.pointSymbol, props.type]);
 
   return {
+    // prop getters
     getFirstLabelProps,
     getSecondLabelProps,
     getFirstInputProps,
@@ -340,9 +351,16 @@ const useDartboard = (userProps={}) => {
     getButtonProps,
     getFirstHelpProps,
     getSecondHelpProps,
-    isFirstInputValid: firstIsValid,
+    // actions
+    setFirstIsValid,
+    setSecondIsValid,
+    setFound,
+    // state
     isSecondInputValid: secondIsValid,
-    found
+    isFirstInputValid: firstIsValid,
+    found,
+    firstInput,
+    secondInput
   };
 };
 

--- a/packages/dartboard/src/Dartboard.stories.js
+++ b/packages/dartboard/src/Dartboard.stories.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Dartboard from './Dartboard';
+import { TailwindDartboard } from './Dartboard';
 
 export default {
   title: 'Dartboard',
@@ -9,14 +10,18 @@ export default {
   }
 };
 
-export const Address = (args) => (
-  <Dartboard apiKey='AGRC-Dev' events={{...args}} />
+export const DefaultAddress = (args) => (
+  <Dartboard apiKey="AGRC-Dev" events={{ ...args }}/>
 );
 
-export const Milepost = (args) => (
-  <Dartboard apiKey="AGRC-Dev" events={{...args}} type = "route-milepost" />
+export const DefaultMilepost = (args) => (
+  <Dartboard apiKey="AGRC-Dev" events={{...args}} type="route-milepost" />
 );
 
-export const Inline = (args) => (
-  <Dartboard apiKey='AGRC-Dev' events={{...args}} inline={true} />
+export const MilepostWithArguments = (args) => (
+  <Dartboard milepost={{ side: "decreasing" }} wkid={26912} format="geojson" apiKey="AGRC-Dev" events={{...args}} type="route-milepost" />
+);
+
+export const AddressWithTailwind = (args) => (
+  <TailwindDartboard apiKey="AGRC-Dev" events={{ ...args }} />
 );

--- a/packages/dartboard/src/Dartboard.stories.js
+++ b/packages/dartboard/src/Dartboard.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Dartboard from './Dartboard';
-import { TailwindDartboard } from './Dartboard';
+import { TailwindDartboard, useDartboard } from './Dartboard';
 
 export default {
   title: 'Dartboard',
@@ -25,3 +25,98 @@ export const MilepostWithArguments = (args) => (
 export const AddressWithTailwind = (args) => (
   <TailwindDartboard apiKey="AGRC-Dev" events={{ ...args }} />
 );
+
+export const HookWithEvents = (args) => {
+  const DartboardHook = (props) => {
+    const { getFirstLabelProps,
+      getSecondLabelProps,
+      getFirstInputProps,
+      getSecondInputProps,
+      getButtonProps,
+      getFirstHelpProps,
+      getSecondHelpProps,
+      setFirstIsValid,
+      setSecondIsValid,
+      isFirstInputValid,
+      isSecondInputValid,
+      found,
+      firstInput,
+      secondInput
+    } = useDartboard(props);
+
+    const validateStreet = (e, input) => {
+      let valid = false;
+      const length = e?.target.value.length || input.length;
+
+      if (length >= 4 || length < 1) {
+        valid = true;
+      }
+
+      setFirstIsValid(valid);
+      return valid;
+    };
+
+    const validateZip = (e, input) => {
+      let valid = false;
+      const value = e?.target.value || input;
+      const length = value.length;
+
+      if ((length < 1 || length === 5) && value.startsWith('841')) {
+        valid = true;
+      }
+
+      setSecondIsValid(valid);
+      return valid;
+    };
+
+    return (
+      <div className="dartboard">
+        <div className="group">
+          <label {...getFirstLabelProps()}></label>
+          <input
+            {...getFirstInputProps({
+              beforeKeyUp: (e) => validateStreet(e, firstInput)
+            })}
+            className="mb-2 block mt-1 bg-white rounded border border-gray-400 text-gray-700 focus:outline-none focus:border-indigo-500 w-full text-base px-3 py-2"
+          ></input>
+          {!isFirstInputValid ?
+            <small {...getFirstHelpProps()}
+              className="block text-red-600 text-xs -mt-2"></small>
+            : null}
+        </div>
+        <div className="group">
+          <label {...getSecondLabelProps()}>Zip code</label>
+          <input
+            {...getSecondInputProps({
+              beforeKeyUp: (e) => validateZip(e, secondInput)
+            })}
+            className="mb-2 block mt-1 bg-white rounded border border-gray-400 text-gray-700 focus:outline-none focus:border-indigo-500 w-full text-base px-3 py-2"
+          ></input>
+          {!isSecondInputValid ?
+            <small {...getSecondHelpProps()}
+              className="block text-red-600 text-xs -mt-2"></small>
+            : null}
+        </div>
+        <div className="group">
+          <button
+            {...getButtonProps({
+              beforeClick: () => validateStreet(null, firstInput) && validateZip(null, secondInput)
+            })}
+            className="text-black bg-white border border-gray-800 py-1 px-3 focus:outline-none hover:bg-gray-800 hover:text-white transition duration-200 rounded text-lg mt-4"
+          >Find</button>
+          {(() => {
+            if (found === false) {
+              return <small className="ml-3 text-red-600 text-xs">No match found</small>;
+            } else if (found === true) {
+              return <small className="ml-3 text-lg">✅</small>;
+            } else {
+              return null;
+            }
+          })()}
+        </div>
+      </div>
+    );
+  };
+
+  return <DartboardHook apiKey='agrc-dev' events={{...args}}></DartboardHook>;
+};

--- a/packages/dartboard/src/common.js
+++ b/packages/dartboard/src/common.js
@@ -1,5 +1,6 @@
 export const toQueryString = (obj) =>
   Object.keys(obj)
-    .map((key) => encodeURIComponent(key) + '=' + encodeURIComponent(obj[key]))
+    .filter(key => obj[key] !== null)
+    .map(key => encodeURIComponent(key) + '=' + encodeURIComponent(obj[key]))
     .join('&')
     .replace(/%20/g, '+');


### PR DESCRIPTION
this converts dartboard into a useDartboard hook with render props. It allows for 

- milepost or single address type geocoding
- all of the options that the web api allows to mix in and the output types

It is missing a render prop for 

- the match text depending on the `found` state
- the ability to replace the validation method
- the ability to replace the find method

It is a drop in replacement for our typical use cases so I vote that we try to release this as the next major version.